### PR TITLE
Bugfixes - two warnings, one deprecated notice

### DIFF
--- a/functions/save-fields.php
+++ b/functions/save-fields.php
@@ -186,6 +186,10 @@ function wpfep_save_password( $tabs, $user_id ) {
 	/* set an array to store messages in */
 	$messages = array();
 	
+	/* check to see if there is a password to set */
+        if ( empty( $_POST[ 'password' ] ) )
+                return;
+	
 	/* get the posted data from the password tab */
 	$data = $_POST[ 'password' ];
 	

--- a/functions/wpfep-functions.php
+++ b/functions/wpfep-functions.php
@@ -186,7 +186,7 @@ function wpfep_field( $field, $classes, $tab_id, $user_id ) {
 			    	);
 			    	
 			    	/* buld field name */
-			    	$wysiwyg_name = $tab_id . '[' . $field[ 'id' ] . ']';
+			    	$wysiwyg_name = $tab_id . '_' . $field[ 'id' ];
 			    						    	
 			    	/* display the wysiwyg editor */
 			    	wp_editor(

--- a/wp-fronted-profile.php
+++ b/wp-fronted-profile.php
@@ -122,7 +122,7 @@ function wpfep_show_profile() {
 						<?php
 							
 							/* check if callback function exists */
-							if( function_exists( $wpfep_tab[ 'callback' ] ) ) {
+							if( ! empty( $wpfep_tab[ 'callback' ] ) && function_exists( $wpfep_tab[ 'callback' ] ) ) {
 								
 								/* use custom callback function */
 								$wpfep_tab[ 'callback' ]( $wpfep_tab );


### PR DESCRIPTION
For your consideration.

This PR fixes two PHP warnings and one WP deprecated notice:

Notice: Undefined index: callback in wp-content/plugins/wp-front-end-profile/wp-fronted-profile.php on line 126

Notice: Undefined index: password in wp-content/plugins/wp-front-end-profile/functions/save-fields.php on line 190

Notice:  wp_editor() was called with an argument that is <strong>deprecated</strong> since version 3.9.0! TinyMCE editor IDs cannot have brackets. in wp-includes/functions.php on line 4021