### PR TITLE
Fix php error when accessing users data value

### DIFF
--- a/functions/wpfep-functions.php
+++ b/functions/wpfep-functions.php
@@ -158,7 +158,7 @@ function wpfep_field( $field, $classes, $tab_id, $user_id ) {
 			if( in_array( $field[ 'id' ], $reserved_ids ) ) {
 				
 				$userdata = get_userdata( $user_id );
-				$current_field_value = $userdata->$field[ 'id' ];
+				$current_field_value = $userdata->{$field[ 'id' ]};
 			
 			/* not a reserved id - treat normally */
 			} else {


### PR DESCRIPTION
I'd been getting the following warning on my local.  It was also reported here: https://wordpress.org/support/topic/php-warning-in-log-2/.

This PR has fixed the error for me.

```
PHP Warning: Illegal string offset 'id' in /home/THE_DOMAIN/public_html/wp-content/plugins/wp-front-end-profile/functions/wpfep-functions.php on line 161
```